### PR TITLE
Replace deprecated methods

### DIFF
--- a/api-mcorg.lua
+++ b/api-mcorg.lua
@@ -229,7 +229,7 @@ mobs.default_definition = {
 	end,
 	
 	on_step = function(self, dtime)
-		if self.type == "monster" and minetest.setting_getbool("only_peaceful_mobs") then
+		if self.type == "monster" and minetest.settings:get_bool("only_peaceful_mobs") then
 			self.object:remove()
 		end
 		
@@ -355,7 +355,7 @@ mobs.default_definition = {
 			do_env_damage(self)
 		end
 		
-		if self.type == "monster" and minetest.setting_getbool("enable_damage") then
+		if self.type == "monster" and minetest.settings:get_bool("enable_damage") then
 			for _,player in pairs(minetest.get_connected_players()) do
 				local s = self.object:getpos()
 				local p = player:getpos()
@@ -602,7 +602,7 @@ mobs.default_definition = {
 		self.attack = {player = nil, dist = nil}
 		self.object:setvelocity({x=0, y=self.object:getvelocity().y, z=0})
 		self.object:setyaw(math.random(1, 360)/180*math.pi)
-		if self.type == "monster" and minetest.setting_getbool("only_peaceful_mobs") then
+		if self.type == "monster" and minetest.settings:get_bool("only_peaceful_mobs") then
 			self.object:remove()
 		end
 		self.lifetimer = 600 - dtime_s
@@ -768,7 +768,7 @@ end
 
 mobs.spawning_mobs = {}
 function mobs:register_spawn(name, nodes, max_light, min_light, chance, active_object_count, max_height, spawn_func)
-	if minetest.setting_getbool(string.gsub(name,":","_").."_spawn") ~= false then
+	if minetest.settings:get_bool(string.gsub(name,":","_").."_spawn") ~= false then
 		mobs.spawning_mobs[name] = true
 		minetest.register_abm({
 			nodenames = nodes,
@@ -811,7 +811,7 @@ function mobs:register_spawn(name, nodes, max_light, min_light, chance, active_o
 				if mobs:check_player_dist(pos, node) then
 					return
 				end
-				if minetest.setting_getbool("display_mob_spawn") then
+				if minetest.settings:get_bool("display_mob_spawn") then
 					minetest.chat_send_all("[mobs] Add "..name.." at "..minetest.pos_to_string(pos))
 				end
 				minetest.add_entity(pos, name)
@@ -860,7 +860,7 @@ minetest.register_craftitem(mob, {
 		if pointed_thing.above and not minetest.is_protected(pos, placer:get_player_name()) then
 			pos.y = pos.y + 0.5
 			minetest.add_entity(pos, mob)
-			if not minetest.setting_getbool("creative_mode") then
+			if not minetest.settings:get_bool("creative_mode") then
 				itemstack:take_item()
 			end
 		end

--- a/api-mm-mcmods.lua
+++ b/api-mm-mcmods.lua
@@ -11,12 +11,12 @@ mobs = {}
 mobs.mod = "redo"
 
 -- Load settings
-local damage_enabled = minetest.setting_getbool("enable_damage")
-local peaceful_only = minetest.setting_getbool("only_peaceful_mobs")
-local disable_blood = minetest.setting_getbool("mobs_disable_blood")
-local creative = minetest.setting_getbool("creative_mode")
-local spawn_protected = tonumber(minetest.setting_get("mobs_spawn_protected")) or 1
-local remove_far = minetest.setting_getbool("remove_far_mobs")
+local damage_enabled = minetest.settings:get_bool("enable_damage")
+local peaceful_only = minetest.settings:get_bool("only_peaceful_mobs")
+local disable_blood = minetest.settings:get_bool("mobs_disable_blood")
+local creative = minetest.settings:get_bool("creative_mode")
+local spawn_protected = tonumber(minetest.settings:get("mobs_spawn_protected")) or 1
+local remove_far = minetest.settings:get_bool("remove_far_mobs")
 
 -- pathfinding settings
 local enable_pathfinding = false
@@ -2360,7 +2360,7 @@ function mobs:spawn_specific(name, nodes, neighbors, min_light, max_light,
 	interval, chance, active_object_count, min_height, max_height, day_toggle)
 
 	-- chance override in minetest.conf for registered mob
-	local new_chance = tonumber(minetest.setting_get(name .. "_chance"))
+	local new_chance = tonumber(minetest.settings:get(name .. "_chance"))
 
 	if new_chance ~= nil then
 

--- a/chicken.lua
+++ b/chicken.lua
@@ -195,6 +195,6 @@ mobs:alias_mob("mobs:chicken", "mobs_mc:chicken")
 mobs:register_egg("mobs_mc:chicken", "Chicken", "spawn_egg_chicken.png")
 
 
-if minetest.setting_get("log_mods") then
+if minetest.settings:get("log_mods") then
 	minetest.log("action", "MC chicken loaded")
 end

--- a/cow.lua
+++ b/cow.lua
@@ -171,6 +171,6 @@ mobs:alias_mob("mobs:cow", "mobs_mc:cow")
 mobs:register_egg("mobs_mc:cow", "Cow", "spawn_egg_cow.png")
 
 
-if minetest.setting_get("log_mods") then
+if minetest.settings:get("log_mods") then
 	minetest.log("action", "MC Cow loaded")
 end

--- a/creeper.lua
+++ b/creeper.lua
@@ -110,6 +110,6 @@ mobs:alias_mob("mobs:creeper", "mobs_mc:creeper")
 mobs:register_egg("mobs_mc:creeper", "Creeper", "spawn_egg_creeper.png")
 
 
-if minetest.setting_get("log_mods") then
+if minetest.settings:get("log_mods") then
 	minetest.log("action", "MC Creeper loaded")
 end

--- a/enderman.lua
+++ b/enderman.lua
@@ -79,6 +79,6 @@ mobs:register_spawn("mobs_mc:enderman", { "default:sand", "default:desert_sand"}
 mobs:register_egg("mobs_mc:enderman", "Enderman", "spawn_egg_overlay.png")
 
 
-if minetest.setting_get("log_mods") then
+if minetest.settings:get("log_mods") then
 	minetest.log("action", "MC Enderman loaded")
 end

--- a/ghast.lua
+++ b/ghast.lua
@@ -124,6 +124,6 @@ mobs:register_arrow(":mobs_monster:fireball", {
 mobs:register_egg("mobs_mc:ghast", "Ghast", "ghast_front.png")
 
 
-if minetest.setting_get("log_mods") then
+if minetest.settings:get("log_mods") then
 	minetest.log("action", "MC Ghast loaded")
 end

--- a/horse.lua
+++ b/horse.lua
@@ -354,6 +354,6 @@ mobs:register_egg("mobs_mc:horsepegh1", "Tamed White Horse", "mobs_horse_peg_inv
 mobs:register_egg("mobs_mc:horsearah1", "Tamed Arabic Horse", "mobs_horse_ara_inv.png", 0)
 
 
-if minetest.setting_get("log_mods") then
+if minetest.settings:get("log_mods") then
 	minetest.log("action", "MC Horse loaded")
 end

--- a/pig.lua
+++ b/pig.lua
@@ -74,7 +74,7 @@ mobs:register_mob("mobs_mc:pig", {
 				min = 1,
 				max = 1,},
 			}
-			if not minetest.setting_getbool("creative_mode") then
+			if not minetest.settings:get_bool("creative_mode") then
 				local inv = clicker:get_inventory()
 				local stack = inv:get_stack("main", clicker:get_wield_index())
 				stack:take_item()
@@ -243,6 +243,6 @@ mobs:alias_mob("mobs:pig", "mobs_mc:pig")
 mobs:register_egg("mobs_mc:pig", "Pig", "spawn_egg_pig.png")
 
 
-if minetest.setting_get("log_mods") then
+if minetest.settings:get("log_mods") then
 	minetest.log("action", "MC Pig loaded")
 end

--- a/sheep.lua
+++ b/sheep.lua
@@ -62,13 +62,13 @@ mobs:register_mob("mobs_mc:sheep", {
 		local item = clicker:get_wielded_item()
 		if item:get_name() == "farming:wheat" then
 			if not self.tamed then
-				if not minetest.setting_getbool("creative_mode") then
+				if not minetest.settings:get_bool("creative_mode") then
 					item:take_item()
 					clicker:set_wielded_item(item)
 				end
 				self.tamed = true
 			elseif self.naked then
-				if not minetest.setting_getbool("creative_mode") then
+				if not minetest.settings:get_bool("creative_mode") then
 					item:take_item()
 					clicker:set_wielded_item(item)
 				end
@@ -96,7 +96,7 @@ mobs:register_mob("mobs_mc:sheep", {
 			self.object:set_properties({
 				textures = {"sheep_sheared.png"},
 			})
-			if not minetest.setting_getbool("creative_mode") then
+			if not minetest.settings:get_bool("creative_mode") then
 				item:add_wear(300)
 				clicker:get_inventory():set_stack("main", clicker:get_wield_index(), item)
 			end
@@ -154,6 +154,6 @@ mobs:alias_mob("mobs:sheep", "mobs_mc:sheep")
 mobs:register_egg("mobs_mc:sheep", "Sheep", "spawn_egg_sheep.png")
 
 
-if minetest.setting_get("log_mods") then
+if minetest.settings:get("log_mods") then
 	minetest.log("action", "MC Sheep loaded")
 end

--- a/skeleton.lua
+++ b/skeleton.lua
@@ -282,7 +282,7 @@ arrows = {
 local throwing_shoot_arrow = function(itemstack, player)
 	for _,arrow in ipairs(arrows) do
 		if player:get_inventory():get_stack("main", player:get_wield_index()+1):get_name() == arrow[1] then
-			if not minetest.setting_getbool("creative_mode") then
+			if not minetest.settings:get_bool("creative_mode") then
 				player:get_inventory():remove_item("main", arrow[1])
 			end
 			local playerpos = player:getpos()
@@ -309,7 +309,7 @@ minetest.register_tool(":mobs:bow_wood", {
     stack_max = 1,
 	on_use = function(itemstack, user, pointed_thing)
 		if throwing_shoot_arrow(itemstack, user, pointed_thing) then
-			if not minetest.setting_getbool("creative_mode") then
+			if not minetest.settings:get_bool("creative_mode") then
 				itemstack:add_wear(65535/50)
 			end
 		end
@@ -335,6 +335,6 @@ mobs:alias_mob("mobs:skeleton", "mobs_mc:skeleton")
 mobs:register_egg("mobs_mc:skeleton", "Skeleton", "spawn_egg_skeleton.png")
 
 
-if minetest.setting_get("log_mods") then
+if minetest.settings:get("log_mods") then
 	minetest.log("action", "MC Skeleton loaded")
 end

--- a/slimes.lua
+++ b/slimes.lua
@@ -363,6 +363,6 @@ mobs:register_egg("mobs_mc:lavabig", "Magma Cube", "spawn_egg_magma_cube.png")
 mobs:register_egg("mobs_mc:greenbig", "Green Slime", "spawn_egg_slime.png")
 
 
-if minetest.setting_get("log_mods") then
+if minetest.settings:get("log_mods") then
 	minetest.log("action", "MC Slimes loaded")
 end

--- a/spider.lua
+++ b/spider.lua
@@ -103,6 +103,6 @@ mobs:alias_mob("esmobs:spider", "mobs_mc:spider")
 mobs:register_egg("mobs_mc:spider", "Spider", "mobs_cobweb.png", 1)
 
 
-if minetest.setting_get("log_mods") then
+if minetest.settings:get("log_mods") then
 	minetest.log("action", "MC Spiders loaded")
 end

--- a/villager.lua
+++ b/villager.lua
@@ -185,6 +185,6 @@ mobs:alias_mob("mobs:villager", "mobs_mc:villager")
 mobs:register_egg("mobs_mc:villager", "Villager", "spawn_egg_villager.png")
 
 
-if minetest.setting_get("log_mods") then
+if minetest.settings:get("log_mods") then
 	minetest.log("action", "MC mobs loaded")
 end

--- a/wolf.lua
+++ b/wolf.lua
@@ -51,7 +51,7 @@ mobs:register_mob("mobs_mc:dog", {
 		if item:get_name() == "mobs:meat_raw" then
 			local hp = self.object:get_hp()
 			if hp + 4 > self.hp_max then return end
-			if not minetest.setting_getbool("creative_mode") then
+			if not minetest.settings:get_bool("creative_mode") then
 				item:take_item()
 				clicker:set_wielded_item(item)
 			end
@@ -193,6 +193,6 @@ mobs:register_egg("mobs_mc:wolf", "Wolf", "wool_grey.png", 1)
 mobs:register_egg("mobs_mc:dog", "Dog", "wool_brown.png", 1)
 
 
-if minetest.setting_get("log_mods") then
+if minetest.settings:get("log_mods") then
 	minetest.log("action", "MC Wolf loaded")
 end

--- a/zombie.lua
+++ b/zombie.lua
@@ -99,6 +99,6 @@ mobs:alias_mob("mobs:zombie", "mobs_mc:zombie")
 mobs:register_egg("mobs_mc:zombie", "Zombie", "spawn_egg_zombie.png")
 
 
-if minetest.setting_get("log_mods") then
+if minetest.settings:get("log_mods") then
 	minetest.log("action", "MC Zombie loaded")
 end

--- a/zombiepig.lua
+++ b/zombiepig.lua
@@ -116,6 +116,6 @@ mobs:alias_mob("mobs:pigman", "mobs_mc:pigman")
 mobs:register_egg("mobs_mc:pigman", "Zombie Pigman", "spawn_egg_zombie_pigman.png")
 
 
-if minetest.setting_get("log_mods") then
+if minetest.settings:get("log_mods") then
 	minetest.log("action", "MC Pigmen loaded")
 end


### PR DESCRIPTION
- 'setting_get' with 'settings:get'
- 'setting_getbool' with 'settings:get_bool'

May not want to merge this until after 0.4.16 release, as the new ['settings' object calls][l_settings] are not available in 0.4.15.

[l_settings]: https://github.com/minetest/minetest/blob/43d1f375d18a2fbc547a9b4f23d1354d645856ca/src/script/lua_api/l_settings.cpp#L267