### PR TITLE
Remove iron golem blood

### DIFF
--- a/iron_golem.lua
+++ b/iron_golem.lua
@@ -65,7 +65,7 @@ mobs:register_mob("mobs_mc:iron_golem", {
 	},
 	jump = true,
 	step = 1,
-	blood_texture = "default_steelblock.png",
+	blood_amount = 0,
 })
 
 


### PR DESCRIPTION
This disables the “blood” particles of iron golems. They are not supposed to have any blood particles.

Fixes #40.