### PR TITLE
Fix possible crash after killing zombie

### DIFF
--- a/0_gameconfig.lua
+++ b/0_gameconfig.lua
@@ -87,6 +87,7 @@ mobs_mc.items = {
 	nether_brick_block = "nether:brick",
 	mycelium = "ethereal:mushroom_dirt",
 	carrot = "farming:carrot",
+	potato = "farming:potato",
 	golden_carrot = "farming:carrot_gold",
 	fishing_rod = "fishing:pole_wood",
 	fish_raw = "fishing:fish_raw",
@@ -95,6 +96,7 @@ mobs_mc.items = {
 	pufferfish_raw = "fishing:pike_raw",
 	bone = "bonemeal:bone",
 	slimeball = "mesecons_materials:glue",
+	apple = "default:apple",
 	golden_apple = "default:apple",
 
 	-- TODO: Add actual ender pearl
@@ -128,9 +130,9 @@ mobs_mc.follow = {
 	sheep = { mobs_mc.items.wheat },
 	cow = { mobs_mc.items.wheat },
 	chicken = { "farming:seed_wheat", "farming:seed_cotton" },
-	horse = { "default:apple", mobs_mc.items.sugar, mobs_mc.items.wheat, mobs_mc.items.hay_bale, mobs_mc.items.golden_apple, mobs_mc.items.golden_carrot }, -- TODO
-	pig = { "farming:potato", mobs_mc.items.carrot, mobs_mc.items.carrot_on_a_stick,
-		"default:apple", -- Minetest Game extra
+	horse = { mobs_mc.items.apple, mobs_mc.items.sugar, mobs_mc.items.wheat, mobs_mc.items.hay_bale, mobs_mc.items.golden_apple, mobs_mc.items.golden_carrot }, -- TODO
+	pig = { mobs_mc.items.potato, mobs_mc.items.carrot, mobs_mc.items.carrot_on_a_stick,
+		mobs_mc.items.apple, -- Minetest Game extra
 	},
 	rabbit = { mobs_mc.items.dandelion, mobs_mc.items.carrot, mobs_mc.items.carrot_gold, "farming_plus:carrot_item", },
 	ocelot = { mobs_mc.items.fish_raw, mobs_mc.items.salmon_raw, mobs_mc.items.clownfish_raw, mobs_mc.items.pufferfish_raw,


### PR DESCRIPTION
Fixes possible crash after killing zombie. The problem was that some entries in the `follows` table ended up being `nil`.