### PR TITLE
Spawn balancing

### DIFF
--- a/chicken.lua
+++ b/chicken.lua
@@ -95,7 +95,7 @@ mobs:register_mob("mobs_mc:chicken", {
 })
 
 --spawn
-mobs:register_spawn("mobs_mc:chicken", mobs_mc.spawn.grassland, minetest.LIGHT_MAX+1, 9, 17000, 3, 31000)
+mobs:register_spawn("mobs_mc:chicken", mobs_mc.spawn.grassland, minetest.LIGHT_MAX+1, 9, 7000, 3, 31000)
 
 -- spawn eggs
 mobs:register_egg("mobs_mc:chicken", S("Chicken"), "mobs_mc_spawn_icon_chicken.png", 0)

--- a/cow+mooshroom.lua
+++ b/cow+mooshroom.lua
@@ -134,8 +134,8 @@ mobs:register_mob("mobs_mc:mooshroom", mooshroom_def)
 
 
 -- Spawning
-mobs:register_spawn("mobs_mc:cow", mobs_mc.spawn.grassland, minetest.LIGHT_MAX+1, 9, 17000, 20, 31000)
-mobs:register_spawn("mobs_mc:mooshroom", mobs_mc.spawn.mushroom_island, minetest.LIGHT_MAX+1, 9, 17000, 10, 31000)
+mobs:register_spawn("mobs_mc:cow", mobs_mc.spawn.grassland, minetest.LIGHT_MAX+1, 9, 7000, 20, 31000)
+mobs:register_spawn("mobs_mc:mooshroom", mobs_mc.spawn.mushroom_island, minetest.LIGHT_MAX+1, 9, 7000, 10, 31000)
 
 
 -- compatibility

--- a/creeper.lua
+++ b/creeper.lua
@@ -122,7 +122,7 @@ mobs:register_mob("mobs_mc:creeper", {
 })
 
 
-mobs:spawn_specific("mobs_mc:creeper", mobs_mc.spawn.solid, {"air"},0, 7, 20, 16500, 1, -310, 31000)
+mobs:spawn_specific("mobs_mc:creeper", mobs_mc.spawn.solid, {"air"},0, 7, 20, 5000, 1, -310, 31000)
 
 -- compatibility
 mobs:alias_mob("mobs:creeper", "mobs_mc:creeper")

--- a/enderman.lua
+++ b/enderman.lua
@@ -147,8 +147,8 @@ mobs:register_mob("mobs_mc:enderman", {
 
 
 --spawn on solid blocks
-mobs:register_spawn("mobs_mc:enderman", mobs_mc.spawn.desert, 7, 0, 9000, -31000, 31000)
-mobs:register_spawn("mobs_mc:enderman", mobs_mc.end_city, minetest.LIGHT_MAX+1, 0, 9000, -31000, -5000)
+mobs:register_spawn("mobs_mc:enderman", mobs_mc.spawn.solid, 7, 0, 7500, -31000, 31000)
+mobs:register_spawn("mobs_mc:enderman", mobs_mc.end_city, minetest.LIGHT_MAX+1, 0, 5000, -31000, -5000)
 -- spawn eggs
 mobs:register_egg("mobs_mc:enderman", S("Enderman"), "mobs_mc_spawn_icon_enderman.png", 0)
 

--- a/ghast.lua
+++ b/ghast.lua
@@ -77,8 +77,8 @@ mobs:register_mob("mobs_mc:ghast", {
 })
 
 
---mobs:register_spawn("mobs_mc:ghast", {"default:flowing_lava", "nether:rack","air"}, 17, -1, 5000, 1, -2000)
-mobs:spawn_specific("mobs_mc:ghast", mobs_mc.spawn.nether, {"air"},0, minetest.LIGHT_MAX+1, 0, 18000, 2, -3610, -2100)
+mobs:spawn_specific("mobs_mc:ghast", mobs_mc.spawn.nether, {"air"},0, minetest.LIGHT_MAX+1, 0, 5000, 2, -3610, -2100)
+
 -- fireball (weapon)
 mobs:register_arrow(":mobs_monster:fireball", {
 	visual = "sprite",

--- a/guardian.lua
+++ b/guardian.lua
@@ -80,7 +80,7 @@ mobs:register_mob("mobs_mc:guardian", {
 	blood_amount = 0,
 })
 
-mobs:register_spawn("mobs_mc:guardian", mobs_mc.spawn.water, minetest.LIGHT_MAX+1, 0, 5000, 2, -1000, true)
+mobs:register_spawn("mobs_mc:guardian", mobs_mc.spawn.water, minetest.LIGHT_MAX+1, 0, 19000, 2, -1000, true)
 
 -- spawn eggs
 mobs:register_egg("mobs_mc:guardian", S("Guardian"), "mobs_mc_spawn_icon_guardian.png", 0)

--- a/guardian_elder.lua
+++ b/guardian_elder.lua
@@ -85,7 +85,7 @@ mobs:register_mob("mobs_mc:guardian_elder", {
 	blood_amount = 0,
 })
 
-mobs:register_spawn("mobs_mc:guardian_elder", mobs_mc.spawn.water, minetest.LIGHT_MAX+1, 0, 5000, 2, -1000, true)
+mobs:register_spawn("mobs_mc:guardian_elder", mobs_mc.spawn.water, minetest.LIGHT_MAX+1, 0, 50000, 2, -1000, true)
 
 -- spawn eggs
 mobs:register_egg("mobs_mc:guardian_elder", S("Elder Guardian"), "mobs_mc_spawn_icon_guardian_elder.png", 0)

--- a/horse.lua
+++ b/horse.lua
@@ -329,8 +329,8 @@ mobs:register_mob("mobs_mc:mule", mule)
 
 --===========================
 --Spawn Function
-mobs:register_spawn("mobs_mc:horse", mobs_mc.spawn.grassland_savanna, minetest.LIGHT_MAX+1, 0, 15000, 12, 31000)
-mobs:register_spawn("mobs_mc:donkey", mobs_mc.spawn.grassland_savanna, minetest.LIGHT_MAX+1, 0, 15000, 12, 31000)
+mobs:register_spawn("mobs_mc:horse", mobs_mc.spawn.grassland_savanna, minetest.LIGHT_MAX+1, 0, 10000, 12, 31000)
+mobs:register_spawn("mobs_mc:donkey", mobs_mc.spawn.grassland_savanna, minetest.LIGHT_MAX+1, 0, 11000, 12, 31000)
 
 
 -- compatibility

--- a/llama.lua
+++ b/llama.lua
@@ -139,7 +139,7 @@ mobs:register_mob("mobs_mc:llama", {
 })
 
 --spawn
-mobs:register_spawn("mobs_mc:llama", mobs_mc.spawn.savanna, minetest.LIGHT_MAX+1, 0, 15000, 1, 40)
+mobs:register_spawn("mobs_mc:llama", mobs_mc.spawn.savanna, minetest.LIGHT_MAX+1, 0, 6500, 1, 40)
 
 -- spawn eggs
 mobs:register_egg("mobs_mc:llama", S("Llama"), "mobs_mc_spawn_icon_llama.png", 0)

--- a/pig.lua
+++ b/pig.lua
@@ -168,7 +168,7 @@ mobs:register_mob("mobs_mc:pig", {
 	end,
 })
 
-mobs:register_spawn("mobs_mc:pig", mobs_mc.spawn.grassland, minetest.LIGHT_MAX+1, 9, 15000, 30, 31000)
+mobs:register_spawn("mobs_mc:pig", mobs_mc.spawn.grassland, minetest.LIGHT_MAX+1, 9, 5000, 30, 31000)
 
 -- compatibility
 mobs:alias_mob("mobs:pig", "mobs_mc:pig")

--- a/rabbit.lua
+++ b/rabbit.lua
@@ -104,7 +104,7 @@ mobs:register_mob("mobs_mc:killer_bunny", killer_bunny)
 
 local spawn = {
 	name = "mobs_mc:rabbit",
-	chance = 15000,
+	chance = 5000,
 	active_object_count = 99,
 	min_light = 0,
 	max_light = minetest.LIGHT_MAX+1,

--- a/sheep.lua
+++ b/sheep.lua
@@ -199,7 +199,7 @@ mobs:register_mob("mobs_mc:sheep", {
 		if mobs:capture_mob(self, clicker, 0, 5, 70, false, nil) then return end
 	end,
 })
-mobs:register_spawn("mobs_mc:sheep", mobs_mc.spawn.grassland, minetest.LIGHT_MAX+1, 0, 15000, 3, 31000)
+mobs:register_spawn("mobs_mc:sheep", mobs_mc.spawn.grassland, minetest.LIGHT_MAX+1, 0, 5000, 3, 31000)
 
 -- compatibility
 mobs:alias_mob("mobs_animal:sheep", "mobs_mc:sheep")

--- a/shulker.lua
+++ b/shulker.lua
@@ -83,7 +83,7 @@ mobs:register_arrow("mobs_mc:shulkerbullet", {
 
 mobs:register_egg("mobs_mc:shulker", S("Shulker"), "mobs_mc_spawn_icon_shulker.png", 0)
 
-mobs:spawn_specific("mobs_mc:shulker", mobs_mc.spawn.end_city, 0, minetest.LIGHT_MAX+1, 5, 3, 1, -31000, -5000)
+mobs:spawn_specific("mobs_mc:shulker", mobs_mc.spawn.end_city, 0, minetest.LIGHT_MAX+1, 5, 5000, 1, -31000, -5000)
 
 
 

--- a/silverfish.lua
+++ b/silverfish.lua
@@ -30,7 +30,7 @@ mobs:register_mob("mobs_mc:silverfish", {
 	lava_damage = 4,
 	light_damage = 0,
 	fear_height = 4,
-	replace_what = mobs_mc.replace_silverfish,
+	replace_what = mobs_mc.replace.silverfish,
 	replace_rate = 2,
 	animation = {
 		speed_normal = 25,		speed_run = 50,

--- a/skeleton+stray.lua
+++ b/skeleton+stray.lua
@@ -120,9 +120,9 @@ mobs:register_mob("mobs_mc:stray", stray)
 mobs:alias_mob("mobs:skeleton", "mobs_mc:skeleton")
 
 --spawn
-mobs:spawn_specific("mobs_mc:skeleton", mobs_mc.spawn.solid,{"air"}, 0, 7, 20, 17000, 2, -110, 31000)
+mobs:spawn_specific("mobs_mc:skeleton", mobs_mc.spawn.solid,{"air"}, 0, 7, 20, 5000, 2, -110, 31000)
 -- TODO: Spawn directly under the sky
-mobs:spawn_specific("mobs_mc:stray", mobs_mc.spawn.snow, {"air"}, 0, 7, 20, 19000, 2, -110, 31000)
+mobs:spawn_specific("mobs_mc:stray", mobs_mc.spawn.snow, {"air"}, 0, 7, 20, 9000, 2, -110, 31000)
 
 -- spawn eggs
 mobs:register_egg("mobs_mc:skeleton", S("Skeleton"), "mobs_mc_spawn_icon_skeleton.png", 0)

--- a/slime+magma_cube.lua
+++ b/slime+magma_cube.lua
@@ -119,9 +119,9 @@ slime_tiny.on_die = nil
 mobs:register_mob("mobs_mc:slime_tiny", slime_tiny)
 
 
-mobs:register_spawn("mobs_mc:slime_tiny", mobs_mc.spawn.solid, minetest.LIGHT_MAX+1, 0, 35000, 4, -12)
-mobs:register_spawn("mobs_mc:slime_small", mobs_mc.spawn.solid, minetest.LIGHT_MAX+1, 0, 35000, 4, -12)
-mobs:register_spawn("mobs_mc:slime_big", mobs_mc.spawn.solid, minetest.LIGHT_MAX+1, 0, 35000, 4, -12)
+mobs:register_spawn("mobs_mc:slime_tiny", mobs_mc.spawn.solid, minetest.LIGHT_MAX+1, 0, 6000, 4, -12)
+mobs:register_spawn("mobs_mc:slime_small", mobs_mc.spawn.solid, minetest.LIGHT_MAX+1, 0, 6000, 4, -12)
+mobs:register_spawn("mobs_mc:slime_big", mobs_mc.spawn.solid, minetest.LIGHT_MAX+1, 0, 6000, 4, -12)
 
 
 -- Magma cube
@@ -241,13 +241,13 @@ mobs:register_mob("mobs_mc:magma_cube_tiny", magma_cube_tiny)
 
 
 
-mobs:register_spawn("mobs_mc:magma_cube_tiny", mobs_mc.spawn.nether, minetest.LIGHT_MAX+1, 0, 15000, 4, -1000)
-mobs:register_spawn("mobs_mc:magma_cube_small", mobs_mc.spawn.nether, minetest.LIGHT_MAX+1, 0, 15500, 4, -1000)
-mobs:register_spawn("mobs_mc:magma_cube_big", mobs_mc.spawn.nether, minetest.LIGHT_MAX+1, 0, 16000, 4, -1000)
+mobs:register_spawn("mobs_mc:magma_cube_tiny", mobs_mc.spawn.nether, minetest.LIGHT_MAX+1, 0, 8000, 4, -1000)
+mobs:register_spawn("mobs_mc:magma_cube_small", mobs_mc.spawn.nether, minetest.LIGHT_MAX+1, 0, 9000, 4, -1000)
+mobs:register_spawn("mobs_mc:magma_cube_big", mobs_mc.spawn.nether, minetest.LIGHT_MAX+1, 0, 10000, 4, -1000)
 
-mobs:register_spawn("mobs_mc:magma_cube_tiny", mobs_mc.spawn.nether_fortress, minetest.LIGHT_MAX+1, 0, 11000, 4, -1000)
-mobs:register_spawn("mobs_mc:magma_cube_small", mobs_mc.spawn.nether_fortress, minetest.LIGHT_MAX+1, 0, 11100, 4, -1000)
-mobs:register_spawn("mobs_mc:magma_cube_big", mobs_mc.spawn.nether_fortress, minetest.LIGHT_MAX+1, 0, 11200, 4, -1000)
+mobs:register_spawn("mobs_mc:magma_cube_tiny", mobs_mc.spawn.nether_fortress, minetest.LIGHT_MAX+1, 0, 4000, 4, -1000)
+mobs:register_spawn("mobs_mc:magma_cube_small", mobs_mc.spawn.nether_fortress, minetest.LIGHT_MAX+1, 0, 4500, 4, -1000)
+mobs:register_spawn("mobs_mc:magma_cube_big", mobs_mc.spawn.nether_fortress, minetest.LIGHT_MAX+1, 0, 5000, 4, -1000)
 
 -- Compability
 mobs:alias_mob("mobs_mc:greensmall", "mobs_mc:slime_tiny")

--- a/spider.lua
+++ b/spider.lua
@@ -76,7 +76,7 @@ cave_spider.walk_velocity = 4.1
 mobs:register_mob("mobs_mc:cave_spider", cave_spider)
 
 
-mobs:register_spawn("mobs_mc:spider", mobs_mc.spawn.solid, 7, 0, 19500, 2, 3000)
+mobs:register_spawn("mobs_mc:spider", mobs_mc.spawn.solid, 7, 0, 7000, 2, 3000)
 
 
 -- compatibility

--- a/zombie.lua
+++ b/zombie.lua
@@ -120,11 +120,11 @@ mobs:register_mob("mobs_mc:baby_husk", baby_husk)
 
 -- Spawning
 
-mobs:register_spawn("mobs_mc:zombie", mobs_mc.spawn.solid, 7, 0, 6000, 4, 31000)
+mobs:register_spawn("mobs_mc:zombie", mobs_mc.spawn.solid, 7, 0, 4000, 4, 31000)
 -- Baby zombie is 20 times less likely than regular zombies
-mobs:register_spawn("mobs_mc:baby_zombie", mobs_mc.spawn.solid, 7, 0, 60000, 4, 31000)
-mobs:register_spawn("mobs_mc:husk", mobs_mc.spawn.desert, 7, 0, 6500, 4, 31000)
-mobs:register_spawn("mobs_mc:baby_husk", mobs_mc.spawn.desert, 7, 0, 65000, 4, 31000)
+mobs:register_spawn("mobs_mc:baby_zombie", mobs_mc.spawn.solid, 7, 0, 40000, 4, 31000)
+mobs:register_spawn("mobs_mc:husk", mobs_mc.spawn.desert, 7, 0, 4900, 4, 31000)
+mobs:register_spawn("mobs_mc:baby_husk", mobs_mc.spawn.desert, 7, 0, 49000, 4, 31000)
 
 
 -- Compatibility


### PR DESCRIPTION
Currently, it can take quite a while until a mob finally spawns. This PR increases the overall likelihood of most mobs spawning.

Guardian + elder guardian spawn rate is reduced, those mobs are intended to be rare.

Also fixes a code typo regarding silverfish.