### PR TITLE
Set pathfinding=1 for enderman and witch

### DIFF
--- a/enderman.lua
+++ b/enderman.lua
@@ -21,7 +21,7 @@ local place_frequency = 10
 mobs:register_mob("mobs_mc:enderman", {
 	type = "monster",
 	runaway = true,
-	pathfinding = 2,
+	pathfinding = 1,
 	stepheight = 1.2,
 	hp_min = 40,
 	hp_max = 40,

--- a/witch.lua
+++ b/witch.lua
@@ -31,7 +31,7 @@ mobs:register_mob("mobs_mc:witch", {
 	damage = 2,
 	walk_velocity = 1.2,
 	run_velocity = 2.4,
-	pathfinding = 2,
+	pathfinding = 1,
 	group_attack = true,
 	attack_type = "dogshoot",
 	arrow = "mobs:potion_arrow",


### PR DESCRIPTION
Reason: `pathfinding=2` activates building and digging blocks when following the player. This behaviour is not desired for any mob and also causes problems with blocks which should never be dug.

Fixes #112.