### PR TITLE
Fix game crash when using mobs_mc_gameconfig

### DIFF
--- a/0_gameconfig.lua
+++ b/0_gameconfig.lua
@@ -325,7 +325,7 @@ if minetest.get_modpath("mobs_mc_gameconfig") and mobs_mc.override then
 	if mobs_mc.override.enderman_replace_on_take then
 		mobs_mc.enderman_replace_on_take = mobs_mc.override.enderman_replace_on_take
 	end
-	if mobs_mc.enderman_block_texture_overrides then
+	if mobs_mc.override.enderman_block_texture_overrides then
 		mobs_mc.enderman_block_texture_overrides = mobs_mc.override.enderman_block_texture_overrides
 	end
 end


### PR DESCRIPTION
When mobs_mc_gameconfig mod exists and mobs_mc.override.enderman_block_texture_overrides is not defined, the game crashes on any encounter with enderman.